### PR TITLE
Mobile layout - Container height tweak

### DIFF
--- a/src/components/linksbar/linksbar.css
+++ b/src/components/linksbar/linksbar.css
@@ -43,7 +43,7 @@ div.link--block div.link--container a {
 
 div.link--block div.link--container div.link--block-content {
   width: 100%;
-  height: 150px;
+  height: 180px;
 }
 
 div.link--block div.link--container div.link__links {


### PR DESCRIPTION
🚧 On the mobile layout, the text gets cut off so you can not see the project description properly.

✅ The height of the container increased to 180px which is sufficient to cover the length.